### PR TITLE
Add direct domain pricing link

### DIFF
--- a/doc_source/Route53Pricing.md
+++ b/doc_source/Route53Pricing.md
@@ -2,4 +2,6 @@
 
 As with other AWS products, there are no contracts or minimum commitments for using Amazon Route 53\. You pay only for the hosted zones that you configure and the number of DNS queries that Route 53 answers\. For more information, see [Amazon Route 53 Pricing](https://aws.amazon.com/route53/pricing/)\.
 
+For pricing for domain registration, see [Amazon Route 53 Pricing for Domain Registration](https://d32ze2gidvkk54.cloudfront.net/Amazon_Route_53_Domain_Registration_Pricing_20140731.pdf)\.
+
 For information about billing for AWS services, including how to view your bill and manage your account and payments, see the [AWS Billing User Guide](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/)\.


### PR DESCRIPTION
Proposal to add a direct link to the pricing for domain registration, as it is currently a real hassle to access the prices for registering a domain name with Route 53 with first having to go to the general pricing page, then having to search and scroll a long time to finally reach the particular paragraph. As Amazon is known to be the most customer-friendly company in the world, also the pricing for domain registration on AWS should be accessible in the most hassle-free way. :)
